### PR TITLE
hash-url-routing-for-iframe

### DIFF
--- a/src/app/terra-components-doc.component.ts
+++ b/src/app/terra-components-doc.component.ts
@@ -1,4 +1,5 @@
 import {
+    AfterViewInit,
     Component,
     ModuleWithProviders,
     OnInit
@@ -20,9 +21,10 @@ import { isNullOrUndefined } from 'util';
     template: require('./terra-components-doc.component.html'),
     styles:   [require('./terra-components-doc.component.scss')],
 })
-export class AppComponent implements OnInit
+export class AppComponent implements OnInit , AfterViewInit
 {
     private _mainViews:any;
+    private hashValue: string;
 
     public constructor(private _routeResolver:RouteResolver,
                        private _dynamicModuleBuilderService:DynamicModuleBuilderService,
@@ -39,6 +41,18 @@ export class AppComponent implements OnInit
             //}
         ];
     }
+
+    ngAfterViewInit()
+    {
+        if(window.parent.window.location.hash)
+        {
+            this.hashValue = window.parent.window.location.hash.toLowerCase();
+            this.hashValue = this.hashValue.replace('#','');
+            this.router.navigateByUrl( '/'+this.hashValue);
+        }
+    }
+
+
 
     ngOnInit():void
     {

--- a/src/app/views/components/main-view/main-view.component.ts
+++ b/src/app/views/components/main-view/main-view.component.ts
@@ -1,4 +1,5 @@
-import {
+import
+{
     AfterViewInit,
     Component,
     ComponentRef,
@@ -40,10 +41,10 @@ export class DynamicPluginLoaderComponent implements AfterViewInit, OnDestroy, O
     private _isActiveButton:boolean;
     private _hideExample:boolean;
 
-    private _htlmPath:string;
+    private _htmlPath:string;
     private _cssPath:string;
     private _apiPath:string;
-    private _typescripPath:string;
+    private _typescriptPath:string;
     private _componentName:string;
     private _apiHtml:any;
     private _overviewMarkDownPath:string;
@@ -60,12 +61,12 @@ export class DynamicPluginLoaderComponent implements AfterViewInit, OnDestroy, O
                 public http:Http)
     {
         this._temp = '';
-        this._htlmPath = '';
+        this._htmlPath = '';
         this._cssPath = '';
         this._htmlCode = '';
         this._cssCode = '';
         this._typescriptCode = '';
-        this._typescripPath = '';
+        this._typescriptPath = '';
         this._isActive = false;
         this._isActiveButton = false;
         this._hideExample = false;
@@ -85,13 +86,13 @@ export class DynamicPluginLoaderComponent implements AfterViewInit, OnDestroy, O
 
     ngOnInit()
     {
-        this._htlmPath = this._activatedRoute.routeConfig.data.htmlPath;
+        this._htmlPath = this._activatedRoute.routeConfig.data.htmlPath;
         this._cssPath = this._activatedRoute.routeConfig.data.cssPath;
-        this._typescripPath = this._activatedRoute.routeConfig.data.tsPath;
+        this._typescriptPath = this._activatedRoute.routeConfig.data.tsPath;
         this._componentName = this._activatedRoute.routeConfig.data.componentName;
         this._alert.closeAlertByIdentifier('info');
 
-        this.http.get(this._htlmPath).finally(() =>
+        this.http.get(this._htmlPath).finally(() =>
         {
             this.checkTemplate(this._htmlCode);
         }).subscribe((res:any) =>
@@ -110,7 +111,7 @@ export class DynamicPluginLoaderComponent implements AfterViewInit, OnDestroy, O
             this._cssHighlight = `<pre><code class="css highlight">${this._cssCode}</code></pre>`;
         });
 
-        this.http.get(this._typescripPath).finally(() =>
+        this.http.get(this._typescriptPath).finally(() =>
         {
         }).subscribe((res:any) =>
         {
@@ -135,6 +136,7 @@ export class DynamicPluginLoaderComponent implements AfterViewInit, OnDestroy, O
             default:
                 break;
         }
+        window.parent.window.location.hash = '#' + this._componentName;
     }
 
     ngOnDestroy()


### PR DESCRIPTION
**ADD**: function to ngAfterViewInit to automatically root to a hash value(component-name as hash) if one is set in the URL.
Hash Value is added on every component load and is set equal to the component name so that you can root from the main-site Url into an iframe.